### PR TITLE
Feat: Handle mocking API calls in tests

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -318,6 +318,22 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
+name = "responses"
+version = "0.17.0"
+description = "A utility library for mocking out the `requests` Python library."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.dependencies]
+requests = ">=2.0"
+six = "*"
+urllib3 = ">=1.25.10"
+
+[package.extras]
+tests = ["coverage (>=3.7.1,<6.0.0)", "pytest-cov", "pytest-localserver", "flake8", "types-mock", "types-requests", "types-six", "pytest (>=4.6,<5.0)", "pytest (>=4.6)", "mypy"]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -348,6 +364,14 @@ description = "List processing tools and functional utilities"
 category = "main"
 optional = false
 python-versions = ">=3.5"
+
+[[package]]
+name = "unittest"
+version = "0.0"
+description = ""
+category = "main"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "urllib3"
@@ -389,7 +413,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "0f51427334a9add4d2fbc1ebe49365d94c8710cb1ef2b1302c302a93cdbc7a9e"
+content-hash = "89f65fc9f8b6ff39b77bde15d6b516471eaa205ddad90ee7b2b281730d350afa"
 
 [metadata.files]
 altair = [
@@ -674,6 +698,10 @@ requests = [
     {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
     {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
 ]
+responses = [
+    {file = "responses-0.17.0-py2.py3-none-any.whl", hash = "sha256:e4fc472fb7374fb8f84fcefa51c515ca4351f198852b4eb7fc88223780b472ea"},
+    {file = "responses-0.17.0.tar.gz", hash = "sha256:ec675e080d06bf8d1fb5e5a68a1e5cd0df46b09c78230315f650af5e4036bec7"},
+]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
@@ -689,6 +717,9 @@ tomli = [
 toolz = [
     {file = "toolz-0.11.2-py3-none-any.whl", hash = "sha256:a5700ce83414c64514d82d60bcda8aabfde092d1c1a8663f9200c07fdcc6da8f"},
     {file = "toolz-0.11.2.tar.gz", hash = "sha256:6b312d5e15138552f1bda8a4e66c30e236c831b612b2bf0005f8a1df10a4bc33"},
+]
+unittest = [
+    {file = "unittest2-0.0.0.tar.gz", hash = "sha256:1b492484bea7f68abda5fcc61412e77b6a105e5842355d630f8b75f01add3555"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.8-py2.py3-none-any.whl", hash = "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ numpy = "^1.22.1"
 pandas = "^1.3.5"
 requests = "^2.27.1"
 python-dotenv = "^0.19.2"
+unittest = "^0.0"
+responses = "^0.17.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/src/airpyllution/airpyllution.py
+++ b/src/airpyllution/airpyllution.py
@@ -1,6 +1,5 @@
 import requests
-import pandas as pd
-from .utils import convert_unix_to_date
+from airpyllution.utils import *
 
 # import constants
 OPEN_WEATHER_MAP_URL = 'http://api.openweathermap.org/data/2.5/air_pollution/history' 
@@ -65,7 +64,6 @@ def get_pollution_history(start_date, end_date, lat, lon, api_key):
         return "end_date input should be an int"
 
     url = OPEN_WEATHER_MAP_URL
-    method = 'GET'
     params = {
         'lat': lat,
         'lon': lon,
@@ -75,12 +73,11 @@ def get_pollution_history(start_date, end_date, lat, lon, api_key):
     }
 
     
-    response = requests.request(method=method, url=url, params=params)
-    response_obj = dict(response.json())
+    response = requests.get(url=url, params=params)
+    response_obj = response.json()
 
     try: 
-        data = pd.DataFrame.from_records(list(map(lambda x:x["components"],response_obj["list"])))
-        data["dt"] = list(map(lambda x:convert_unix_to_date(x["dt"]),response_obj["list"]))
+        data = convert_data_to_pandas(response_obj)
 
         return data
 
@@ -88,9 +85,8 @@ def get_pollution_history(start_date, end_date, lat, lon, api_key):
         if 'cod' in response_obj:
             return response_obj['message']
         
-        return "An error occurred requesting data from"
+        return "An error occurred requesting data from the API"
     
-
 
 def get_air_pollution(lat, lon, api_key):
     """Returns a map depicting varying pollution levels for a specified location.

--- a/src/airpyllution/airpyllution.py
+++ b/src/airpyllution/airpyllution.py
@@ -2,7 +2,7 @@ import requests
 from airpyllution.utils import *
 
 # import constants
-OPEN_WEATHER_MAP_URL = 'http://api.openweathermap.org/data/2.5/air_pollution/history' 
+OPEN_WEATHER_MAP_URL = 'http://api.openweathermap.org/data/2.5/air_pollution/' 
 
 def get_pollution_history(start_date, end_date, lat, lon, api_key):
     """Returns a dataframe of pollution history for a location between a specified date range
@@ -63,7 +63,7 @@ def get_pollution_history(start_date, end_date, lat, lon, api_key):
     if not isinstance(end_date, int):
         return "end_date input should be an int"
 
-    url = OPEN_WEATHER_MAP_URL
+    url = OPEN_WEATHER_MAP_URL + 'history'
     params = {
         'lat': lat,
         'lon': lon,

--- a/src/airpyllution/utils.py
+++ b/src/airpyllution/utils.py
@@ -1,5 +1,6 @@
 
 from datetime import datetime
+import pandas as pd
 
 def convert_unix_to_date(utime):
     """Returns formatted date time string
@@ -20,3 +21,25 @@ def convert_unix_to_date(utime):
     """ 
     ts = int(utime)
     return datetime.utcfromtimestamp(ts).strftime('%Y-%m-%d %H:%M:%S')
+
+
+def convert_data_to_pandas(raw_data):
+    """Converts API data from OpenWeatherMap to a pandas dataframe
+    
+    Parses the JSON data object and transforms it to a dataframe with a formatted
+    date column
+
+    Parameters
+    ----------
+    raw_data : JSON object
+
+    Returns
+    -------
+    Pandas.dataframe
+    Examples
+    --------
+    >>> convert_data_to_pandas(data)
+    """ 
+    data = pd.DataFrame.from_records(list(map(lambda x:x["components"],raw_data["list"])))
+    data["dt"] = list(map(lambda x:convert_unix_to_date(x["dt"]),raw_data["list"]))
+    return data

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -82,3 +82,19 @@ mock_api_invalid_key_error = {
    'cod': 401, 
    'message': 'Invalid API key. Please see http://openweathermap.org/faq#error401 for more info.' 
    }
+
+mock_params = {
+   'lat': 49.28,
+   'lon': 123.12,
+   'start': 1606488670,
+   'end': 1606747870,
+   'appid': 'mock_api_key'
+}
+
+mock_incorrect_params = {
+   'lat': 'latitude_val',
+   'lon': 'longitude_val',
+   'start': 1234.567,
+   'end': 3.14159,
+   'appid': 'invalid_api_key'
+}

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,0 +1,84 @@
+mock_history_data = {
+        "coord": [
+            50.0,
+            50.0
+        ],
+        "list": [
+            {
+            "main": {
+                "aqi": 2
+            },
+            "components": {
+                "co": 270.367,
+                "no": 5.867,
+                "no2": 43.184,
+                "o3": 4.783,
+                "so2": 14.544,
+                "pm2_5": 13.448,
+                "pm10": 15.524,
+                "nh3": 0.289
+            },
+            "dt": 1606482000
+            },
+            {
+            "main": {
+                "aqi": 2
+            },
+            "components": {
+                "co": 280.38,
+                "no": 8.605,
+                "no2": 42.155,
+                "o3": 2.459,
+                "so2": 14.901,
+                "pm2_5": 15.103,
+                "pm10": 17.249,
+                "nh3": 0.162
+            },
+            "dt": 1606478400
+            }]
+    }
+
+mock_forecast_data = {
+        "coord": [
+            50.0,
+            50.0
+        ],
+        "list": [
+            {
+            "main": {
+                "aqi": 2
+            },
+            "components": {
+                "co": 270.367,
+                "no": 5.867,
+                "no2": 43.184,
+                "o3": 4.783,
+                "so2": 14.544,
+                "pm2_5": 13.448,
+                "pm10": 15.524,
+                "nh3": 0.289
+            },
+            "dt": 1606482000
+            },
+            {
+            "main": {
+                "aqi": 2
+            },
+            "components": {
+                "co": 280.38,
+                "no": 8.605,
+                "no2": 42.155,
+                "o3": 2.459,
+                "so2": 14.901,
+                "pm2_5": 15.103,
+                "pm10": 17.249,
+                "nh3": 0.162
+            },
+            "dt": 1606478400
+            }]
+    }
+
+mock_api_invalid_key_error = {
+   'cod': 401, 
+   'message': 'Invalid API key. Please see http://openweathermap.org/faq#error401 for more info.' 
+   }

--- a/tests/test_airpyllution.py
+++ b/tests/test_airpyllution.py
@@ -1,7 +1,35 @@
 from airpyllution import airpyllution
 import pandas as pd
+from pandas._testing import assert_frame_equal
+from unittest.mock import patch
+from constants import *
+from airpyllution.utils import *
 
-def test_pollution_history():
+
+def mocked_requests_get_pollution_history(*args, **kwargs):
+    class MockResponse:
+        def __init__(self, json_data, status_code):
+            self.json_data = json_data
+            self.status_code = status_code
+
+        def json(self):
+            return self.json_data
+    print(kwargs)
+    if kwargs['url'] == 'http://api.openweathermap.org/data/2.5/air_pollution/history':
+
+        if kwargs['params']['appid'] == 'invalid_api_key':
+            return MockResponse(mock_api_invalid_key_error, 404)
+
+        return MockResponse(mock_history_data, 200)
+
+    elif kwargs['url'] == 'http://api.openweathermap.org/data/2.5/air_pollution/forecast':
+        return MockResponse(mock_forecast_data, 200)
+    
+    return MockResponse({'cod': 401, 'message': 'Invalid API key. Please see http://openweathermap.org/faq#error401 for more info.' }, 404)
+
+
+@patch('requests.get', side_effect=mocked_requests_get_pollution_history)
+def test_pollution_history(mock_api_call):
     """Test word counting from a file."""
     mock_params = {
         'lat': 49.28,
@@ -16,9 +44,10 @@ def test_pollution_history():
         'lon': 'longitude_val',
         'start': 1234.567,
         'end': 3.14159,
-        'appid': 'fake'
+        'appid': 'invalid_api_key'
     }
 
+    # Invalid input type
     assert airpyllution.get_pollution_history(
         mock_incorrect_params['start'], 
         mock_params['end'], 
@@ -26,6 +55,7 @@ def test_pollution_history():
         mock_params['lon'], 
         mock_params['appid']) == "start_date input should be an int"
 
+    # Invalid input type
     assert airpyllution.get_pollution_history(
         mock_params['start'], 
         mock_incorrect_params['end'], 
@@ -33,6 +63,7 @@ def test_pollution_history():
         mock_params['lon'], 
         mock_params['appid']) == "end_date input should be an int"
 
+    # Invalid input type
     assert airpyllution.get_pollution_history(
         mock_params['start'], 
         mock_params['end'], 
@@ -40,6 +71,7 @@ def test_pollution_history():
         mock_params['lon'], 
         mock_params['appid']) == "Latitude input should be a float"
     
+    # Invalid input type
     assert airpyllution.get_pollution_history(
         mock_params['start'], 
         mock_params['end'], 
@@ -47,9 +79,21 @@ def test_pollution_history():
         mock_incorrect_params['lon'], 
         mock_params['appid']) == "Longitude input should be a float"
 
+    # Invalid API key
     assert airpyllution.get_pollution_history(
         mock_params['start'], 
         mock_params['end'], 
         mock_params['lat'], 
         mock_params['lon'], 
         mock_incorrect_params['appid']) == 'Invalid API key. Please see http://openweathermap.org/faq#error401 for more info.'
+
+    # Test for correct pandas output
+    pollution_data_frame = airpyllution.get_pollution_history(
+        mock_params['start'], 
+        mock_params['end'], 
+        mock_params['lat'], 
+        mock_params['lon'], 
+        mock_params['appid'])
+    
+    assert_frame_equal(pollution_data_frame, convert_data_to_pandas(mock_history_data))
+

--- a/tests/test_airpyllution.py
+++ b/tests/test_airpyllution.py
@@ -30,22 +30,7 @@ def mocked_requests_get_pollution_history(*args, **kwargs):
 
 @patch('requests.get', side_effect=mocked_requests_get_pollution_history)
 def test_pollution_history(mock_api_call):
-    """Test word counting from a file."""
-    mock_params = {
-        'lat': 49.28,
-        'lon': 123.12,
-        'start': 1606488670,
-        'end': 1606747870,
-        'appid': 'mock_api_key'
-    }
-
-    mock_incorrect_params = {
-        'lat': 'latitude_val',
-        'lon': 'longitude_val',
-        'start': 1234.567,
-        'end': 3.14159,
-        'appid': 'invalid_api_key'
-    }
+    """Test fetching pollution history from API"""
 
     # Invalid input type
     assert airpyllution.get_pollution_history(


### PR DESCRIPTION
- [X] Handles mocking the API requests calls using [responses library](https://github.com/getsentry/responses) and [unit test mocks](https://docs.python.org/3/library/unittest.mock-examples.html)
- [X] Change the API call to be a `requests.get()` method rather than `requests.request()` method
- [X] Move the data -> pandas dataframe code to `utils.py`
- [X] Add mocked data to a `tests/constants.py` file
- [X] Create a `MockResponse` object that handles returning different data for different API requests calls

@danfke @christopheralex it would be cool if you guys had a look at this (and the corresponding github issue) and check how i've created the `MockedResponse` object.

Chris - Ideally this PR gets merged in before yours but it means you'll need to go back to your PR and refactor some things (I will deffo help if using the Mocked response is unclear!)
This doesn't require your api_key as you'll be providing the response data in the `tests/constants.py` file which is what the `requests.get` function will return. 

Currently, all of these tests are passing - but pls let me know if you have questions, or if things are unclear!