### PR TITLE
Chore: Add linter, codecov, fix code styling

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -84,6 +84,18 @@ python-versions = ">=3.5.0"
 unicode_backport = ["unicodedata2"]
 
 [[package]]
+name = "codecov"
+version = "2.1.12"
+description = "Hosted coverage reports for GitHub, Bitbucket and Gitlab"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+coverage = "*"
+requests = ">=2.7.9"
+
+[[package]]
 name = "colorama"
 version = "0.4.4"
 description = "Cross-platform colored terminal text."
@@ -496,7 +508,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "fa5ab8e69decf7f6caa75a049f9b43a94a7c11382dc0e465c1a350af314c2ecb"
+content-hash = "656ea95c5f3d5513f611ecf8c6f4aa8c1666482a561b77d6bd5e2716e9a910f9"
 
 [metadata.files]
 altair = [
@@ -526,6 +538,11 @@ certifi = [
 charset-normalizer = [
     {file = "charset-normalizer-2.0.10.tar.gz", hash = "sha256:876d180e9d7432c5d1dfd4c5d26b72f099d503e8fcc0feb7532c9289be60fcbd"},
     {file = "charset_normalizer-2.0.10-py3-none-any.whl", hash = "sha256:cb957888737fc0bbcd78e3df769addb41fd1ff8cf950dc9e7ad7793f1bf44455"},
+]
+codecov = [
+    {file = "codecov-2.1.12-py2.py3-none-any.whl", hash = "sha256:585dc217dc3d8185198ceb402f85d5cb5dbfa0c5f350a5abcdf9e347776a5b47"},
+    {file = "codecov-2.1.12-py3.8.egg", hash = "sha256:782a8e5352f22593cbc5427a35320b99490eb24d9dcfa2155fd99d2b75cfb635"},
+    {file = "codecov-2.1.12.tar.gz", hash = "sha256:a0da46bb5025426da895af90938def8ee12d37fcbcbbbc15b6dc64cf7ebc51c1"},
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -65,6 +65,32 @@ tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)"
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
+name = "black"
+version = "21.12b0"
+description = "The uncompromising code formatter."
+category = "main"
+optional = false
+python-versions = ">=3.6.2"
+
+[package.dependencies]
+click = ">=7.1.2"
+mypy-extensions = ">=0.4.3"
+pathspec = ">=0.9.0,<1"
+platformdirs = ">=2"
+tomli = ">=0.2.6,<2.0.0"
+typing-extensions = [
+    {version = ">=3.10.0.0", markers = "python_version < \"3.10\""},
+    {version = "!=3.10.0.1", markers = "python_version >= \"3.10\""},
+]
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.7.4)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+python2 = ["typed-ast (>=1.4.3)"]
+uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
 name = "certifi"
 version = "2021.10.8"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -84,6 +110,17 @@ python-versions = ">=3.5.0"
 unicode_backport = ["unicodedata2"]
 
 [[package]]
+name = "click"
+version = "8.0.3"
+description = "Composable command line interface toolkit"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
 name = "codecov"
 version = "2.1.12"
 description = "Hosted coverage reports for GitHub, Bitbucket and Gitlab"
@@ -99,7 +136,7 @@ requests = ">=2.7.9"
 name = "colorama"
 version = "0.4.4"
 description = "Cross-platform colored terminal text."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -226,6 +263,14 @@ docs = ["sphinx"]
 test = ["pytest (<5.4)", "pytest-cov"]
 
 [[package]]
+name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "numpy"
 version = "1.22.1"
 description = "NumPy is the fundamental package for array computing with Python."
@@ -264,6 +309,26 @@ pytz = ">=2017.3"
 
 [package.extras]
 test = ["hypothesis (>=3.58)", "pytest (>=6.0)", "pytest-xdist"]
+
+[[package]]
+name = "pathspec"
+version = "0.9.0"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[[package]]
+name = "platformdirs"
+version = "2.4.1"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["Sphinx (>=4)", "furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)"]
+test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
 
 [[package]]
 name = "plotly"
@@ -483,11 +548,11 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "tomli"
-version = "2.0.0"
+version = "1.2.3"
 description = "A lil' TOML parser"
-category = "dev"
+category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.6"
 
 [[package]]
 name = "toolz"
@@ -504,6 +569,14 @@ description = "Tornado is a Python web framework and asynchronous networking lib
 category = "main"
 optional = false
 python-versions = ">= 3.5"
+
+[[package]]
+name = "typing-extensions"
+version = "4.0.1"
+description = "Backported and Experimental Type Hints for Python 3.6+"
+category = "main"
+optional = false
+python-versions = ">=3.6"
 
 [[package]]
 name = "urllib3"
@@ -545,7 +618,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "eb53af34bb1597ba8d9aa5894b2a551e781b4425e6b9570447660861663d9042"
+content-hash = "f4173da21df11b07bd5ad4820668c7b0e1d1a1b1d4a5ce84408afb4b5454877a"
 
 [metadata.files]
 altair = [
@@ -568,6 +641,10 @@ attrs = [
     {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
     {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
 ]
+black = [
+    {file = "black-21.12b0-py3-none-any.whl", hash = "sha256:a615e69ae185e08fdd73e4715e260e2479c861b5740057fde6e8b4e3b7dd589f"},
+    {file = "black-21.12b0.tar.gz", hash = "sha256:77b80f693a569e2e527958459634f18df9b0ba2625ba4e0c2d5da5be42e6f2b3"},
+]
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
     {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
@@ -575,6 +652,10 @@ certifi = [
 charset-normalizer = [
     {file = "charset-normalizer-2.0.10.tar.gz", hash = "sha256:876d180e9d7432c5d1dfd4c5d26b72f099d503e8fcc0feb7532c9289be60fcbd"},
     {file = "charset_normalizer-2.0.10-py3-none-any.whl", hash = "sha256:cb957888737fc0bbcd78e3df769addb41fd1ff8cf950dc9e7ad7793f1bf44455"},
+]
+click = [
+    {file = "click-8.0.3-py3-none-any.whl", hash = "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3"},
+    {file = "click-8.0.3.tar.gz", hash = "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b"},
 ]
 codecov = [
     {file = "codecov-2.1.12-py2.py3-none-any.whl", hash = "sha256:585dc217dc3d8185198ceb402f85d5cb5dbfa0c5f350a5abcdf9e347776a5b47"},
@@ -741,6 +822,10 @@ mock = [
     {file = "mock-4.0.3-py3-none-any.whl", hash = "sha256:122fcb64ee37cfad5b3f48d7a7d51875d7031aaf3d8be7c42e2bee25044eee62"},
     {file = "mock-4.0.3.tar.gz", hash = "sha256:7d3fbbde18228f4ff2f1f119a45cdffa458b4c0dee32eb4d2bb2f82554bac7bc"},
 ]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
 numpy = [
     {file = "numpy-1.22.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3d62d6b0870b53799204515145935608cdeb4cebb95a26800b6750e48884cc5b"},
     {file = "numpy-1.22.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:831f2df87bd3afdfc77829bc94bd997a7c212663889d56518359c827d7113b1f"},
@@ -795,6 +880,14 @@ pandas = [
     {file = "pandas-1.3.5-cp39-cp39-win32.whl", hash = "sha256:c69406a2808ba6cf580c2255bcf260b3f214d2664a3a4197d0e640f573b46fd3"},
     {file = "pandas-1.3.5-cp39-cp39-win_amd64.whl", hash = "sha256:32e1a26d5ade11b547721a72f9bfc4bd113396947606e00d5b4a5b79b3dcb006"},
     {file = "pandas-1.3.5.tar.gz", hash = "sha256:1e4285f5de1012de20ca46b188ccf33521bff61ba5c5ebd78b4fb28e5416a9f1"},
+]
+pathspec = [
+    {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
+    {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
+]
+platformdirs = [
+    {file = "platformdirs-2.4.1-py3-none-any.whl", hash = "sha256:1d7385c7db91728b83efd0ca99a5afb296cab9d0ed8313a45ed8ba17967ecfca"},
+    {file = "platformdirs-2.4.1.tar.gz", hash = "sha256:440633ddfebcc36264232365d7840a970e75e1018d15b4327d11f91909045fda"},
 ]
 plotly = [
     {file = "plotly-5.5.0-py2.py3-none-any.whl", hash = "sha256:bc7d19272560f73fe4c2c989c31b00774a35d3a76891fab0b72c17616862d0e0"},
@@ -922,8 +1015,8 @@ toml = [
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 tomli = [
-    {file = "tomli-2.0.0-py3-none-any.whl", hash = "sha256:b5bde28da1fed24b9bd1d4d2b8cba62300bfb4ec9a6187a957e8ddb9434c5224"},
-    {file = "tomli-2.0.0.tar.gz", hash = "sha256:c292c34f58502a1eb2bbb9f5bbc9a5ebc37bee10ffb8c2d6bbdfa8eb13cc14e1"},
+    {file = "tomli-1.2.3-py3-none-any.whl", hash = "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"},
+    {file = "tomli-1.2.3.tar.gz", hash = "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f"},
 ]
 toolz = [
     {file = "toolz-0.11.2-py3-none-any.whl", hash = "sha256:a5700ce83414c64514d82d60bcda8aabfde092d1c1a8663f9200c07fdcc6da8f"},
@@ -971,6 +1064,10 @@ tornado = [
     {file = "tornado-6.1-cp39-cp39-win32.whl", hash = "sha256:d3d20ea5782ba63ed13bc2b8c291a053c8d807a8fa927d941bd718468f7b950c"},
     {file = "tornado-6.1-cp39-cp39-win_amd64.whl", hash = "sha256:548430be2740e327b3fe0201abe471f314741efcb0067ec4f2d7dcfb4825f3e4"},
     {file = "tornado-6.1.tar.gz", hash = "sha256:33c6e81d7bd55b468d2e793517c909b139960b6c790a60b7991b9b6b76fb9791"},
+]
+typing-extensions = [
+    {file = "typing_extensions-4.0.1-py3-none-any.whl", hash = "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"},
+    {file = "typing_extensions-4.0.1.tar.gz", hash = "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.8-py2.py3-none-any.whl", hash = "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -138,6 +138,19 @@ optional = false
 python-versions = ">=2.7"
 
 [[package]]
+name = "flake8"
+version = "4.0.1"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+mccabe = ">=0.6.0,<0.7.0"
+pycodestyle = ">=2.8.0,<2.9.0"
+pyflakes = ">=2.4.0,<2.5.0"
+
+[[package]]
 name = "idna"
 version = "3.3"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -190,6 +203,14 @@ description = "Safely add untrusted strings to HTML/XML markup."
 category = "main"
 optional = false
 python-versions = ">=3.6"
+
+[[package]]
+name = "mccabe"
+version = "0.6.1"
+description = "McCabe checker, plugin for flake8"
+category = "dev"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "mock"
@@ -297,6 +318,22 @@ description = "library with cross-python path, ini-parsing, io, code, log facili
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "pycodestyle"
+version = "2.8.0"
+description = "Python style guide checker"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "pyflakes"
+version = "2.4.0"
+description = "passive checker of Python programs"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pyparsing"
@@ -508,7 +545,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "656ea95c5f3d5513f611ecf8c6f4aa8c1666482a561b77d6bd5e2716e9a910f9"
+content-hash = "eb53af34bb1597ba8d9aa5894b2a551e781b4425e6b9570447660861663d9042"
 
 [metadata.files]
 altair = [
@@ -605,6 +642,10 @@ entrypoints = [
     {file = "entrypoints-0.3-py2.py3-none-any.whl", hash = "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19"},
     {file = "entrypoints-0.3.tar.gz", hash = "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"},
 ]
+flake8 = [
+    {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
+    {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
+]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
@@ -691,6 +732,10 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
     {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
+]
+mccabe = [
+    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
+    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 mock = [
     {file = "mock-4.0.3-py3-none-any.whl", hash = "sha256:122fcb64ee37cfad5b3f48d7a7d51875d7031aaf3d8be7c42e2bee25044eee62"},
@@ -800,6 +845,14 @@ psutil = [
 py = [
     {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
     {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
+]
+pycodestyle = [
+    {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
+    {file = "pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
+]
+pyflakes = [
+    {file = "pyflakes-2.4.0-py2.py3-none-any.whl", hash = "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"},
+    {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
 ]
 pyparsing = [
     {file = "pyparsing-3.0.7-py3-none-any.whl", hash = "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ responses = "^0.17.0"
 plotly = "^5.5.0"
 altair-viewer = "^0.4.0"
 mock = "^4.0.3"
+black = "^21.12b0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ mock = "^4.0.3"
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"
 pytest-cov = "^3.0.0"
+codecov = "^2.1.12"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ mock = "^4.0.3"
 pytest = "^6.2.5"
 pytest-cov = "^3.0.0"
 codecov = "^2.1.12"
+flake8 = "^4.0.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,6 @@ flake8 = "^4.0.1"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.black]
+line-length = 79

--- a/src/airpyllution/__init__.py
+++ b/src/airpyllution/__init__.py
@@ -1,3 +1,4 @@
 # read version from installed package
 from importlib.metadata import version
+
 __version__ = version("airpyllution")

--- a/src/airpyllution/airpyllution.py
+++ b/src/airpyllution/airpyllution.py
@@ -1,7 +1,8 @@
 import requests
-from airpyllution.utils import *
+from airpyllution.utils import convert_data_to_pandas
 import plotly.express as px
 import altair as alt
+import pandas as pd
 
 alt.renderers.enable("mimetype")
 
@@ -241,7 +242,6 @@ def get_pollution_forecast(lat, lon, api_key):
 
     try:
         response = requests.get(url=url, params=params)
-        print(f"RESPONSE", response)
         response_obj = response.json()
         try:
             data = convert_data_to_pandas(response_obj)

--- a/src/airpyllution/airpyllution.py
+++ b/src/airpyllution/airpyllution.py
@@ -241,7 +241,7 @@ def get_pollution_forecast(lat, lon, api_key):
 
     try:
         response = requests.get(url=url, params=params)
-        print(f'RESPONSE', response)
+        print(f"RESPONSE", response)
         response_obj = response.json()
         try:
             data = convert_data_to_pandas(response_obj)

--- a/src/airpyllution/airpyllution.py
+++ b/src/airpyllution/airpyllution.py
@@ -11,12 +11,15 @@ OPEN_WEATHER_MAP_URL = "http://api.openweathermap.org/data/2.5/air_pollution"
 
 
 def get_pollution_history(start_date, end_date, lat, lon, api_key):
-    """Returns a dataframe of pollution history for a location between a specified date range
+    """Returns a dataframe of pollution history for a location between
+    a specified date range
 
-    Given a specified date range, the function makes an API request to the OpenWeather Air Pollution API and fetches
-    historic pollution data for a given location.
+    Given a specified date range, the function makes an API request to
+    the OpenWeather Air Pollution API and fetches historic pollution data
+    for a given location.
 
-    The function transforms the returned JSON object from the request into a Pandas dataframe.
+    The function transforms the returned JSON object from the request into
+    a Pandas dataframe.
 
     Note: Historical data is accessible from 27th November 2020
 
@@ -35,8 +38,9 @@ def get_pollution_history(start_date, end_date, lat, lon, api_key):
     Returns
     -------
     pandas.DataFrame
-        a dataframe of the data returned from Air Pollution API - columns are as followed:
-        ==========  ==============================================================
+        a dataframe of the data returned from the API.
+        Columns are as followed:
+        ==========  =================================================
         date        int
         co          float: Carbon monoxide
         no          float: Nitrogen monoxide
@@ -46,10 +50,11 @@ def get_pollution_history(start_date, end_date, lat, lon, api_key):
         pm2_5       float: Particulates 2.5
         pm10        float: Particulates 10
         nh3         float: Ammonia
-        ==========  ==============================================================
+        ==========  ==================================================
     Examples
     --------
-    >>> get_pollution_history(1606488670, 1606747870, 49.28, 123.12, "APIKEY_example")
+    >>> get_pollution_history(1606488670, 1606747870, 49.28, 123.12,
+    "APIKEY_example")
     0 1606482000 270.367 5.867 43.184 4.783 14.544 13.448 15.524 0.289
     1 1606478400 280.38 8.605 42.155 2.459 14.901 15.103 17.249 0.162
     2 1606474800 293.732 13.523 41.47 1.173 15.14 17.727 19.929 0.072
@@ -95,10 +100,11 @@ def get_pollution_history(start_date, end_date, lat, lon, api_key):
 def get_air_pollution(lat, lon, api_key, fig_title=""):
     """Returns a map depicting varying pollution levels for a specified location.
 
-    The function makes an API request to the OpenWeather Air Pollution API and fetches
-    pollution data for a given location.
+    The function makes an API request to the OpenWeather Air Pollution
+    API and fetches pollution data for a given location.
 
-    The function transforms the returned JSON object from the request into a plotly plot.
+    The function transforms the returned JSON object from the request
+    into a plotly plot.
 
     Parameters
     ----------
@@ -131,7 +137,9 @@ def get_air_pollution(lat, lon, api_key, fig_title=""):
         return "Enter valid latitude values (Range should be -90<Latitude<90)"
 
     if lon < -180.0 or lon > 180.0:
-        return "Enter valid longitude values (Range should be -180<Longitude<180)"
+        return (
+            "Enter valid longitude values (Range should be -180<Longitude<180)"
+        )
 
     if not isinstance(fig_title, str):
         return "Figure title should be a string"
@@ -197,11 +205,12 @@ def get_air_pollution(lat, lon, api_key, fig_title=""):
 
 
 def get_pollution_forecast(lat, lon, api_key):
-    """Returns a time series plot showing predicted pollutant levels for the next 5 days.
+    """Returns a time series plot showing predicted pollutant levels
+    for the next 5 days.
 
     Performs an API request to OpenWeather Air Pollution API,
-    retrieves weather forecast for the next 5 days, and
-    creates a time series graph of the pollutants with their concentration levels.
+    retrieves weather forecast for the next 5 days, and creates a time series
+    graph of the pollutants with their concentration levels.
 
     Parameters
     ----------
@@ -235,7 +244,9 @@ def get_pollution_forecast(lat, lon, api_key):
         return "Enter valid latitude values (Range should be -90<Latitude<90)"
 
     if lon < -180.0 or lon > 180.0:
-        return "Enter valid longitude values (Range should be -180<Longitude<180)"
+        return (
+            "Enter valid longitude values (Range should be -180<Longitude<180)"
+        )
 
     url = OPEN_WEATHER_MAP_URL + "/forecast"
     params = {"lat": lat, "lon": lon, "appid": api_key}
@@ -255,7 +266,16 @@ def get_pollution_forecast(lat, lon, api_key):
         try:
             data = data.melt(
                 id_vars=["dt"],
-                value_vars=["co", "no", "no2", "o3", "so2", "pm2_5", "pm10", "nh3"],
+                value_vars=[
+                    "co",
+                    "no",
+                    "no2",
+                    "o3",
+                    "so2",
+                    "pm2_5",
+                    "pm10",
+                    "nh3",
+                ],
                 var_name="Pollutants",
                 value_name="Concentration",
             )

--- a/src/airpyllution/utils.py
+++ b/src/airpyllution/utils.py
@@ -5,7 +5,8 @@ import pandas as pd
 def convert_unix_to_date(utime):
     """Returns formatted date time string
 
-    Given a UNIX timestamp, this function reformats the timestamp to a string
+    Given a UNIX timestamp, this function reformats the timestamp
+    to a string
 
     Parameters
     ----------
@@ -26,8 +27,8 @@ def convert_unix_to_date(utime):
 def convert_data_to_pandas(raw_data):
     """Converts API data from OpenWeatherMap to a pandas dataframe
 
-    Parses the JSON data object and transforms it to a dataframe with a formatted
-    date column
+    Parses the JSON data object and transforms it to a dataframe
+    with a formatted date column
 
     Parameters
     ----------

--- a/src/airpyllution/utils.py
+++ b/src/airpyllution/utils.py
@@ -1,10 +1,10 @@
-
 from datetime import datetime
 import pandas as pd
 
+
 def convert_unix_to_date(utime):
     """Returns formatted date time string
-    
+
     Given a UNIX timestamp, this function reformats the timestamp to a string
 
     Parameters
@@ -13,19 +13,19 @@ def convert_unix_to_date(utime):
         UNIX timestamp, e.g. 1606488670
     Returns
     -------
-    datetime 
+    datetime
     Examples
     --------
     >>> date_conversion(1606488670)
     2020-11-27 17:00:00
-    """ 
+    """
     ts = int(utime)
-    return datetime.utcfromtimestamp(ts).strftime('%Y-%m-%d %H:%M:%S')
+    return datetime.utcfromtimestamp(ts).strftime("%Y-%m-%d %H:%M:%S")
 
 
 def convert_data_to_pandas(raw_data):
     """Converts API data from OpenWeatherMap to a pandas dataframe
-    
+
     Parses the JSON data object and transforms it to a dataframe with a formatted
     date column
 
@@ -39,12 +39,16 @@ def convert_data_to_pandas(raw_data):
     Examples
     --------
     >>> convert_data_to_pandas(data)
-    """ 
+    """
     if len(raw_data["list"]) > 1:
-        data = pd.DataFrame.from_records(list(map(lambda x:x["components"],raw_data["list"])))
-        data["dt"] = list(map(lambda x:convert_unix_to_date(x["dt"]),raw_data["list"]))
+        data = pd.DataFrame.from_records(
+            list(map(lambda x: x["components"], raw_data["list"]))
+        )
+        data["dt"] = list(
+            map(lambda x: convert_unix_to_date(x["dt"]), raw_data["list"])
+        )
     else:
-        data  = raw_data["coord"]
+        data = raw_data["coord"]
         data.update(raw_data["list"][0]["components"])
         data = pd.DataFrame.from_records([data])
 

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -88,7 +88,8 @@ mock_forecast_data = {
 
 mock_api_invalid_key_error = {
     "cod": 401,
-    "message": "Invalid API key. Please see http://openweathermap.org/faq#error401 for more info.",
+    "message": "Invalid API key. Please see \
+        http://openweathermap.org/faq#error401 for more info.",
 }
 
 mock_params = {
@@ -118,3 +119,6 @@ mock_error_params = {
     "end": 3.14159,
     "appid": "api_error",
 }
+
+mock_invalid_message = "Invalid API key. Please see \
+    http://openweathermap.org/faq#error401 for more info."

--- a/tests/test_airpyllution.py
+++ b/tests/test_airpyllution.py
@@ -10,10 +10,11 @@ from math import floor
 
 def mocked_requests_get_pollution(*args, **kwargs):
     """
-    Function for mocking a Response object. 
-    This intercepts any API calls when called within the test suite and returns 
+    Function for mocking a Response object.
+    This intercepts any API calls when called within the test suite and returns
     an instance of a MockResponse object. This should be used with the @patch decorator.
     """
+
     class MockResponse:
         def __init__(self, json_data, status_code):
             self.json_data = json_data
@@ -26,7 +27,7 @@ def mocked_requests_get_pollution(*args, **kwargs):
 
         if kwargs["params"]["appid"] == "invalid_api_key":
             return MockResponse(mock_api_invalid_key_error, 404)
-        
+
         if kwargs["params"]["appid"] == "api_error":
             return "ERROR"
 
@@ -36,7 +37,7 @@ def mocked_requests_get_pollution(*args, **kwargs):
 
         if kwargs["params"]["appid"] == "invalid_api_key":
             return MockResponse(mock_api_invalid_key_error, 404)
-        
+
         if kwargs["params"]["appid"] == "api_error":
             return "ERROR"
 
@@ -48,7 +49,7 @@ def mocked_requests_get_pollution(*args, **kwargs):
 
         if kwargs["params"]["appid"] == "invalid_api_key":
             return MockResponse(mock_api_invalid_key_error, 404)
-            
+
         if kwargs["params"]["appid"] == "api_error":
             return "ERROR"
         return MockResponse(mock_forecast_data, 200)
@@ -126,7 +127,7 @@ def test_pollution_history(mock_api_call):
         == "An error occurred requesting data from the API"
     )
 
-    # Invalid API key, tests nested try-except 
+    # Invalid API key, tests nested try-except
     assert (
         airpyllution.get_pollution_history(
             mock_params["start"],
@@ -271,7 +272,9 @@ def test_pollution_forecast(mock_api_call):
 
     assert (
         airpyllution.get_pollution_forecast(
-            mock_params["lat"], mock_params["lon"], mock_error_params["appid"],
+            mock_params["lat"],
+            mock_params["lon"],
+            mock_error_params["appid"],
         )
         == "An error occurred requesting data from the API"
     )

--- a/tests/test_airpyllution.py
+++ b/tests/test_airpyllution.py
@@ -1,9 +1,16 @@
 from airpyllution import airpyllution
-import pandas as pd
 from pandas._testing import assert_frame_equal
 from unittest.mock import patch
-from constants import *
-from airpyllution.utils import *
+from constants import (
+    mock_api_invalid_key_error,
+    mock_error_params,
+    mock_forecast_data,
+    mock_history_data,
+    mock_incorrect_params,
+    mock_params,
+    mock_pollution_data,
+)
+from airpyllution.utils import convert_data_to_pandas
 import altair as alt
 from math import floor
 

--- a/tests/test_airpyllution.py
+++ b/tests/test_airpyllution.py
@@ -9,6 +9,7 @@ from constants import (
     mock_incorrect_params,
     mock_params,
     mock_pollution_data,
+    mock_invalid_message,
 )
 from airpyllution.utils import convert_data_to_pandas
 import altair as alt
@@ -19,7 +20,8 @@ def mocked_requests_get_pollution(*args, **kwargs):
     """
     Function for mocking a Response object.
     This intercepts any API calls when called within the test suite and returns
-    an instance of a MockResponse object. This should be used with the @patch decorator.
+    an instance of a MockResponse object. This should be used with
+    the @patch decorator.
     """
 
     class MockResponse:
@@ -30,7 +32,10 @@ def mocked_requests_get_pollution(*args, **kwargs):
         def json(self):
             return self.json_data
 
-    if kwargs["url"] == "http://api.openweathermap.org/data/2.5/air_pollution/history":
+    if (
+        kwargs["url"]
+        == "http://api.openweathermap.org/data/2.5/air_pollution/history"
+    ):
 
         if kwargs["params"]["appid"] == "invalid_api_key":
             return MockResponse(mock_api_invalid_key_error, 404)
@@ -40,7 +45,9 @@ def mocked_requests_get_pollution(*args, **kwargs):
 
         return MockResponse(mock_history_data, 200)
 
-    elif kwargs["url"] == "http://api.openweathermap.org/data/2.5/air_pollution":
+    elif (
+        kwargs["url"] == "http://api.openweathermap.org/data/2.5/air_pollution"
+    ):
 
         if kwargs["params"]["appid"] == "invalid_api_key":
             return MockResponse(mock_api_invalid_key_error, 404)
@@ -51,7 +58,8 @@ def mocked_requests_get_pollution(*args, **kwargs):
         return MockResponse(mock_pollution_data, 200)
 
     elif (
-        kwargs["url"] == "http://api.openweathermap.org/data/2.5/air_pollution/forecast"
+        kwargs["url"]
+        == "http://api.openweathermap.org/data/2.5/air_pollution/forecast"
     ):
 
         if kwargs["params"]["appid"] == "invalid_api_key":
@@ -64,7 +72,7 @@ def mocked_requests_get_pollution(*args, **kwargs):
     return MockResponse(
         {
             "cod": 401,
-            "message": "Invalid API key. Please see http://openweathermap.org/faq#error401 for more info.",
+            "message": mock_invalid_message,
         },
         404,
     )
@@ -143,7 +151,7 @@ def test_pollution_history(mock_api_call):
             mock_params["lon"],
             mock_incorrect_params["appid"],
         )
-        == "Invalid API key. Please see http://openweathermap.org/faq#error401 for more info."
+        == mock_invalid_message
     )
 
     pollution_data_frame = airpyllution.get_pollution_history(
@@ -154,7 +162,9 @@ def test_pollution_history(mock_api_call):
         mock_params["appid"],
     )
 
-    assert_frame_equal(pollution_data_frame, convert_data_to_pandas(mock_history_data))
+    assert_frame_equal(
+        pollution_data_frame, convert_data_to_pandas(mock_history_data)
+    )
 
 
 @patch("requests.get", side_effect=mocked_requests_get_pollution)
@@ -164,34 +174,44 @@ def test_air_pollution(mock_api_call):
     # Invalid input type
     assert (
         airpyllution.get_air_pollution(
-            mock_incorrect_params["lat"], mock_params["lon"], mock_params["appid"]
+            mock_incorrect_params["lat"],
+            mock_params["lon"],
+            mock_params["appid"],
         )
         == "Latitude input should be a float or an integer"
     )
 
     assert (
         airpyllution.get_air_pollution(
-            mock_params["lat"], mock_incorrect_params["lon"], mock_params["appid"]
+            mock_params["lat"],
+            mock_incorrect_params["lon"],
+            mock_params["appid"],
         )
         == "Longitude input should be a float or an integer"
     )
 
     assert (
-        airpyllution.get_air_pollution(mock_params["lat"], mock_params["lon"], 0)
+        airpyllution.get_air_pollution(
+            mock_params["lat"], mock_params["lon"], 0
+        )
         == "API Key should be a string"
     )
 
     # Invalid input values
     assert (
         airpyllution.get_air_pollution(
-            mock_incorrect_params["lat_oor"], mock_params["lon"], mock_params["appid"]
+            mock_incorrect_params["lat_oor"],
+            mock_params["lon"],
+            mock_params["appid"],
         )
         == "Enter valid latitude values (Range should be -90<Latitude<90)"
     )
 
     assert (
         airpyllution.get_air_pollution(
-            mock_params["lat"], mock_incorrect_params["lon_oor"], mock_params["appid"]
+            mock_params["lat"],
+            mock_incorrect_params["lon_oor"],
+            mock_params["appid"],
         )
         == "Enter valid longitude values (Range should be -180<Longitude<180)"
     )
@@ -208,9 +228,11 @@ def test_air_pollution(mock_api_call):
 
     assert (
         airpyllution.get_air_pollution(
-            mock_params["lat"], mock_params["lon"], mock_incorrect_params["appid"]
+            mock_params["lat"],
+            mock_params["lon"],
+            mock_incorrect_params["appid"],
         )
-        == "Invalid API key. Please see http://openweathermap.org/faq#error401 for more info."
+        == mock_invalid_message
     )
 
     assert (
@@ -245,34 +267,44 @@ def test_pollution_forecast(mock_api_call):
     # Invalid input type
     assert (
         airpyllution.get_pollution_forecast(
-            mock_incorrect_params["lat"], mock_params["lon"], mock_params["appid"]
+            mock_incorrect_params["lat"],
+            mock_params["lon"],
+            mock_params["appid"],
         )
         == "Latitude input should be a float"
     )
 
     assert (
         airpyllution.get_pollution_forecast(
-            mock_params["lat"], mock_incorrect_params["lon"], mock_params["appid"]
+            mock_params["lat"],
+            mock_incorrect_params["lon"],
+            mock_params["appid"],
         )
         == "Longitude input should be a float"
     )
 
     assert (
-        airpyllution.get_pollution_forecast(mock_params["lat"], mock_params["lon"], 0)
+        airpyllution.get_pollution_forecast(
+            mock_params["lat"], mock_params["lon"], 0
+        )
         == "API Key should be a string"
     )
 
     # Invalid input values
     assert (
         airpyllution.get_pollution_forecast(
-            mock_incorrect_params["lat_oor"], mock_params["lon"], mock_params["appid"]
+            mock_incorrect_params["lat_oor"],
+            mock_params["lon"],
+            mock_params["appid"],
         )
         == "Enter valid latitude values (Range should be -90<Latitude<90)"
     )
 
     assert (
         airpyllution.get_pollution_forecast(
-            mock_params["lat"], mock_incorrect_params["lon_oor"], mock_params["appid"]
+            mock_params["lat"],
+            mock_incorrect_params["lon_oor"],
+            mock_params["appid"],
         )
         == "Enter valid longitude values (Range should be -180<Longitude<180)"
     )
@@ -288,9 +320,11 @@ def test_pollution_forecast(mock_api_call):
 
     assert (
         airpyllution.get_pollution_forecast(
-            mock_params["lat"], mock_params["lon"], mock_incorrect_params["appid"]
+            mock_params["lat"],
+            mock_params["lon"],
+            mock_incorrect_params["appid"],
         )
-        == "Invalid API key. Please see http://openweathermap.org/faq#error401 for more info."
+        == mock_invalid_message
     )
 
     # Functionality check with mocked data
@@ -301,6 +335,8 @@ def test_pollution_forecast(mock_api_call):
     assert forecast_chart.columns == 4
     assert len(forecast_chart.data) > 2
     assert len(forecast_chart.data) == 16
-    assert forecast_chart.title == "Pollutant concentration for the next 5 days"
+    assert (
+        forecast_chart.title == "Pollutant concentration for the next 5 days"
+    )
     chart_dict = forecast_chart.to_dict()
     assert chart_dict["facet"] == alt.Facet("Pollutants:N").to_dict()


### PR DESCRIPTION
Package installs:
- codecov
- flake8
- black

Linting:
- Add line length to toml file for black formatter. 
- We should all probably set up auto-save formatting on VS-code. I followed [this setup](https://marcobelo.medium.com/setting-up-python-black-on-visual-studio-code-5318eba4cd00#:~:text=Type%20%E2%80%9Cformat%20on%20save%E2%80%9D%20at,to%20see%20the%20magic%20happen!)

Fixes:
- Fixed line lengths
- Made imports more explicit
- Removed print statement


Run flake8 in terminal
```
poetry run flake8 --exclude=docs*
```
We should only get `E722 do not use bare 'except'` warnings. This is fine as it's not `failing` and therefore shouldn't affect the pipeline. (Dealing with the except warnings are out of scope)
